### PR TITLE
test: add parseFile unit test

### DIFF
--- a/cmd/sshchecker/main_test.go
+++ b/cmd/sshchecker/main_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestParseFile(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "users.txt")
+	content := " user1 \n\n user2\n\t\nuser3  "
+	if err := os.WriteFile(file, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+
+	got, err := parseFile(file)
+	if err != nil {
+		t.Fatalf("parseFile returned error: %v", err)
+	}
+
+	want := []string{"user1", "user2", "user3"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+}


### PR DESCRIPTION
## Summary
- add unit test for parseFile to ensure empty lines are skipped and entries are trimmed

## Testing
- `go test ./cmd/sshchecker`


------
https://chatgpt.com/codex/tasks/task_e_68aaf066f5888321b45d0b2938ba6dd2